### PR TITLE
fix template key

### DIFF
--- a/installer/assets/js/templates.js
+++ b/installer/assets/js/templates.js
@@ -34,7 +34,7 @@ const templates = Object.freeze({
                 "apply": "text"
             },
             {
-                "name": "socket",
+                "name": "lnbitsServer",
                 "type": "ACInput",
                 "value": "",
                 "label": "Copy link from LNURLDevices extension in LNbits",


### PR DESCRIPTION
The template seems a bit off compared to the Arduino file. The template was using `socket` as the variable name and the Arduino was using `lnbitsServer`. I update the template to the key Arduino's using.