### PR TITLE
force wifi scanning

### DIFF
--- a/bitcoinSwitch/bitcoinSwitch.ino
+++ b/bitcoinSwitch/bitcoinSwitch.ino
@@ -5,7 +5,7 @@
 
 String version = "0.1.1";
 
-String ssid = "null"; // 'String ssid = "ssid";' / 'String ssid = "null";'
+String ssid = "null";         // 'String ssid = "ssid";' / 'String ssid = "null";'
 String wifiPassword = "null"; // 'String wifiPassword = "password";' / 'String wifiPassword = "null";'
 
 // String from the lnurlDevice plugin in LNbits lnbits.com
@@ -13,9 +13,9 @@ String switchStr = "null"; // 'String switchStr = "ws url";' / 'String switchStr
 
 // Change for threshold trigger only
 String thresholdInkey; // Invoice/read key for the LNbits wallet you want to watch,  'String thresholdInkey = "key";' / 'String thresholdInkey = "null";'
-long thresholdAmount; // In sats, 'long thresholdAmount = 0;' / 'long thresholdAmount = 100;'
-int thresholdPin; // GPIO pin, 'int thresholdPin = 16;' / 'int thresholdPin;'
-long thresholdTime; // Time to turn pin on, 'long thresholdTime = 2000;' / 'long thresholdTime;'
+long thresholdAmount;  // In sats, 'long thresholdAmount = 0;' / 'long thresholdAmount = 100;'
+int thresholdPin;      // GPIO pin, 'int thresholdPin = 16;' / 'int thresholdPin;'
+long thresholdTime;    // Time to turn pin on, 'long thresholdTime = 2000;' / 'long thresholdTime;'
 
 ///////////////////////////////////////////////////////////////////////////////////
 //                                 END of variables                              //
@@ -52,22 +52,26 @@ int portalPin = 4;
 
 WebSocketsClient webSocket;
 
-struct KeyValue {
+struct KeyValue
+{
     String key;
     String value;
 };
 
-void setup() {
+void setup()
+{
     Serial.begin(115200);
     Serial.println("Welcome to BitcoinSwitch, running on version: " + version);
     bool triggerConfig = false;
     pinMode(2, OUTPUT); // To blink on board LED
     FlashFS.begin(FORMAT_ON_FAIL);
     int timer = 0;
-    while (timer < 2000) {
+    while (timer < 2000)
+    {
         digitalWrite(2, HIGH);
         Serial.println(touchRead(portalPin));
-        if (touchRead(portalPin) < 60) {
+        if (touchRead(portalPin) < 60)
+        {
             triggerConfig = true;
             timer = 5000;
         }
@@ -80,13 +84,18 @@ void setup() {
 
     readFiles(); // get the saved details and store in global variables
 
-    if (triggerConfig == true || ssid == "" || ssid == "null") {
+    if (triggerConfig == true || ssid == "" || ssid == "null")
+    {
         Serial.println("Launch serial config");
         configOverSerialPort();
-    } else {
+    }
+    else
+    {
+        WiFi.setScanMethod(WIFI_ALL_CHANNEL_SCAN); // Force scanning for all APs, not just the first one
         WiFi.begin(ssid.c_str(), wifiPassword.c_str());
         Serial.print("Connecting to WiFi");
-        while (WiFi.status() != WL_CONNECTED) {
+        while (WiFi.status() != WL_CONNECTED)
+        {
             Serial.print(".");
             delay(500);
             digitalWrite(2, HIGH);
@@ -96,12 +105,15 @@ void setup() {
         }
     }
 
-    if (thresholdAmount != 0) { // Use in threshold mode
+    if (thresholdAmount != 0)
+    { // Use in threshold mode
         Serial.println("");
         Serial.println("Using THRESHOLD mode");
         Serial.println("Connecting to websocket: " + urlPrefix + lnbitsServer + apiUrl + thresholdInkey);
         webSocket.beginSSL(lnbitsServer, 443, apiUrl + thresholdInkey);
-    } else { // Use in normal mode
+    }
+    else
+    { // Use in normal mode
         Serial.println("");
         Serial.println("Using NORMAL mode");
         Serial.println("Connecting to websocket: " + urlPrefix + lnbitsServer + apiUrl + deviceId);
@@ -111,21 +123,27 @@ void setup() {
     webSocket.setReconnectInterval(1000);
 }
 
-void loop() {
-    while (WiFi.status() != WL_CONNECTED) { // check wifi again
+void loop()
+{
+    while (WiFi.status() != WL_CONNECTED)
+    { // check wifi again
         Serial.println("Failed to connect");
         delay(500);
     }
     digitalWrite(2, LOW);
     payloadStr = "";
     delay(2000);
-    while (paid == false) { // loop and wait for payment
+    while (paid == false)
+    { // loop and wait for payment
         webSocket.loop();
-        if (paid) {
-            if (thresholdAmount != 0) { // If in threshold mode we check the "balance" pushed by the websocket and use the pin/time preset
+        if (paid)
+        {
+            if (thresholdAmount != 0)
+            { // If in threshold mode we check the "balance" pushed by the websocket and use the pin/time preset
                 StaticJsonDocument<1900> doc;
                 DeserializationError error = deserializeJson(doc, payloadStr);
-                if (error) {
+                if (error)
+                {
                     Serial.print("deserializeJson() failed: ");
                     Serial.println(error.c_str());
                     return;
@@ -136,14 +154,17 @@ void loop() {
                 Serial.println("thresholdSum: " + String(thresholdSum));
                 Serial.println("thresholdAmount: " + String((thresholdAmount * 1000)));
                 Serial.println("thresholdPin: " + String(thresholdPin));
-                if (thresholdSum >= (thresholdAmount * 1000)) {
+                if (thresholdSum >= (thresholdAmount * 1000))
+                {
                     pinMode(thresholdPin, OUTPUT);
                     digitalWrite(thresholdPin, HIGH);
                     delay(thresholdTime);
                     digitalWrite(thresholdPin, LOW);
                     thresholdSum = 0;
                 }
-            } else { // If in normal mode we use the pin/time pushed by the websocket
+            }
+            else
+            { // If in normal mode we use the pin/time pushed by the websocket
                 pinMode(getValue(payloadStr, '-', 0).toInt(), OUTPUT);
                 digitalWrite(getValue(payloadStr, '-', 0).toInt(), HIGH);
                 delay(getValue(payloadStr, '-', 1).toInt());
@@ -157,12 +178,15 @@ void loop() {
 
 //////////////////HELPERS///////////////////
 
-String getValue(String data, char separator, int index) {
+String getValue(String data, char separator, int index)
+{
     int found = 0;
     int strIndex[] = {0, -1};
     int maxIndex = data.length() - 1;
-    for (int i = 0; i <= maxIndex && found <= index; i++) {
-        if (data.charAt(i) == separator || i == maxIndex) {
+    for (int i = 0; i <= maxIndex && found <= index; i++)
+    {
+        if (data.charAt(i) == separator || i == maxIndex)
+        {
             found++;
             strIndex[0] = strIndex[1] + 1;
             strIndex[1] = (i == maxIndex) ? i + 1 : i;
@@ -171,9 +195,12 @@ String getValue(String data, char separator, int index) {
     return found > index ? data.substring(strIndex[0], strIndex[1]) : "";
 }
 
-String getJsonValue(JsonDocument &doc, const char *name) {
-    for (JsonObject elem : doc.as<JsonArray>()) {
-        if (strcmp(elem["name"], name) == 0) {
+String getJsonValue(JsonDocument &doc, const char *name)
+{
+    for (JsonObject elem : doc.as<JsonArray>())
+    {
+        if (strcmp(elem["name"], name) == 0)
+        {
             String value = elem["value"].as<String>();
             return value;
         }
@@ -181,56 +208,70 @@ String getJsonValue(JsonDocument &doc, const char *name) {
     return ""; // return empty string if not found
 }
 
-void readFiles() {
+void readFiles()
+{
     File paramFile = FlashFS.open(PARAM_FILE, "r");
-    if (paramFile) {
+    if (paramFile)
+    {
         StaticJsonDocument<2500> doc;
         DeserializationError error = deserializeJson(doc, paramFile.readString());
-        if (error) {
+        if (error)
+        {
             Serial.print("deserializeJson() failed: ");
             Serial.println(error.c_str());
             return;
         }
-        if (ssid == "null") { // check ssid is not set above
+        if (ssid == "null")
+        { // check ssid is not set above
             ssid = getJsonValue(doc, "ssid");
             Serial.println("");
             Serial.println("SSID used from memory");
             Serial.println("SSID: " + ssid);
-        } else {
+        }
+        else
+        {
             Serial.println("");
             Serial.println("SSID hardcoded");
             Serial.println("SSID: " + ssid);
         }
-        if (wifiPassword == "null") { // check wifiPassword is not set above
+        if (wifiPassword == "null")
+        { // check wifiPassword is not set above
             wifiPassword = getJsonValue(doc, "wifipassword");
             Serial.println("");
             Serial.println("SSID password used from memory");
             Serial.println("SSID password: " + wifiPassword);
-        } else {
+        }
+        else
+        {
             Serial.println("");
             Serial.println("SSID password hardcoded");
             Serial.println("SSID password: " + wifiPassword);
         }
-        if (switchStr == "null") { // check switchStr is not set above
+        if (switchStr == "null")
+        { // check switchStr is not set above
             switchStr = getJsonValue(doc, "socket");
             Serial.println("");
             Serial.println("switchStr used from memory");
             Serial.println("switchStr: " + switchStr);
-        } else {
+        }
+        else
+        {
             Serial.println("");
             Serial.println("switchStr hardcoded");
             Serial.println("switchStr: " + switchStr);
         }
 
         int protocolIndex = switchStr.indexOf("://");
-        if (protocolIndex == -1) {
+        if (protocolIndex == -1)
+        {
             Serial.println("Invalid switchStr: " + switchStr);
             return;
         }
         urlPrefix = switchStr.substring(0, protocolIndex + 3);
 
         int domainIndex = switchStr.indexOf("/", protocolIndex + 3);
-        if (domainIndex == -1) {
+        if (domainIndex == -1)
+        {
             Serial.println("Invalid switchStr: " + switchStr);
             return;
         }
@@ -249,26 +290,28 @@ void readFiles() {
 
 //////////////////WEBSOCKET///////////////////
 
-void webSocketEvent(WStype_t type, uint8_t *payload, size_t length) {
-    switch (type) {
-        case WStype_DISCONNECTED:
-            Serial.printf("[WSc] Disconnected!\n");
-            break;
-        case WStype_CONNECTED:
-            Serial.printf("[WSc] Connected to url: %s\n", payload);
-            webSocket.sendTXT("Connected"); // send message to server when Connected
-            break;
-        case WStype_TEXT:
-            payloadStr = (char *)payload;
-            payloadStr.replace(String("'"), String('"'));
-            payloadStr.toLowerCase();
-            Serial.println("Received data from socket: " + payloadStr);
-            paid = true;
-        case WStype_ERROR:
-        case WStype_FRAGMENT_TEXT_START:
-        case WStype_FRAGMENT_BIN_START:
-        case WStype_FRAGMENT:
-        case WStype_FRAGMENT_FIN:
-            break;
+void webSocketEvent(WStype_t type, uint8_t *payload, size_t length)
+{
+    switch (type)
+    {
+    case WStype_DISCONNECTED:
+        Serial.printf("[WSc] Disconnected!\n");
+        break;
+    case WStype_CONNECTED:
+        Serial.printf("[WSc] Connected to url: %s\n", payload);
+        webSocket.sendTXT("Connected"); // send message to server when Connected
+        break;
+    case WStype_TEXT:
+        payloadStr = (char *)payload;
+        payloadStr.replace(String("'"), String('"'));
+        payloadStr.toLowerCase();
+        Serial.println("Received data from socket: " + payloadStr);
+        paid = true;
+    case WStype_ERROR:
+    case WStype_FRAGMENT_TEXT_START:
+    case WStype_FRAGMENT_BIN_START:
+    case WStype_FRAGMENT:
+    case WStype_FRAGMENT_FIN:
+        break;
     }
 }


### PR DESCRIPTION
The user [Buger Dread](https://github.com/BugerDread) has given good advice in the MakerBits group regarding the instability of the Wifi connection of an ESP32. 

https://t.me/makerbits/20423

By default, the ESP32 scans for access points numerically. The first one is taken. However, the first one does not have to be good. 

There is an extended command `WiFi.setScanMethod` for the ESP32 which forces a scan of all APs before an AP is selected. 

https://github.com/espressif/arduino-esp32/blob/master/libraries/WiFi/src/WiFiSTA.cpp#L230

This must be done before the actual call `WiFi.begin`. 

I tested the code change on a bitcoinSwitch and it worked. 