### PR TITLE
force wifi scanning

### DIFF
--- a/bitcoinSwitch/bitcoinSwitch.ino
+++ b/bitcoinSwitch/bitcoinSwitch.ino
@@ -58,6 +58,7 @@ struct KeyValue {
 };
 
 void setup() {
+    WiFi.setScanMethod(WIFI_ALL_CHANNEL_SCAN); // Force scanning for all APs, not just the first one
     Serial.begin(115200);
     Serial.println("Welcome to BitcoinSwitch, running on version: " + version);
     bool triggerConfig = false;


### PR DESCRIPTION
The user Buger Dread has given good advice in the MakerBits group regarding the instability of the Wifi connection of an ESP32.

https://t.me/makerbits/20423

By default, the ESP32 scans for access points numerically. The first one is taken. However, the first one does not have to be good.

There is an extended command WiFi.setScanMethod for the ESP32 which forces a scan of all APs before an AP is selected.

https://github.com/espressif/arduino-esp32/blob/master/libraries/WiFi/src/WiFiSTA.cpp#L230

This must be done before the actual call WiFi.begin.

I tested the code change on a bitcoinSwitch and it worked.