### PR TITLE
fix: rename `installer` to `hardware-installer` on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ sh build-installer.sh
 ```
 start preview
 ```console
-cd installer
+cd hardware-installer
 http-server -p 8080
 ```
 


### PR DESCRIPTION
Rename `installer` to `hardware-installer` on `README.md`